### PR TITLE
feat: 대기 등록 중복 체크 Redis 전환으로 성능 개선

### DIFF
--- a/src/main/java/com/michelet/waiting/application/port/WaitingActivationPort.java
+++ b/src/main/java/com/michelet/waiting/application/port/WaitingActivationPort.java
@@ -23,4 +23,14 @@ public interface WaitingActivationPort {
     // 대기열에서 제거 - 취소/만료 시 호출
     void remove(UUID restaurantId, String token);
 
+    // 유저 중복 등록 여부 확인 ( Redis )
+    boolean existsUser(UUID restaurantId, UUID userId);
+
+    // 유저 플래그 저장 ( 대기 등록 시 )
+    void addUser(UUID restaurantId, UUID userId);
+
+    // 유저 플래그 제거 ( 취소/완료/만료 시 )
+    void removeUser(UUID restaurantId, UUID userId);
+
+
 }

--- a/src/main/java/com/michelet/waiting/application/port/WaitingActivationPort.java
+++ b/src/main/java/com/michelet/waiting/application/port/WaitingActivationPort.java
@@ -23,11 +23,7 @@ public interface WaitingActivationPort {
     // 대기열에서 제거 - 취소/만료 시 호출
     void remove(UUID restaurantId, String token);
 
-    // 유저 중복 등록 여부 확인 ( Redis )
-    boolean existsUser(UUID restaurantId, UUID userId);
-
-    // 유저 플래그 저장 ( 대기 등록 시 )
-    void addUser(UUID restaurantId, UUID userId);
+    boolean tryAddUser(UUID restaurantId, UUID userId);
 
     // 유저 플래그 제거 ( 취소/완료/만료 시 )
     void removeUser(UUID restaurantId, UUID userId);

--- a/src/main/java/com/michelet/waiting/application/service/WaitingService.java
+++ b/src/main/java/com/michelet/waiting/application/service/WaitingService.java
@@ -48,11 +48,9 @@ public class WaitingService {
     // 대기 등록
     public WaitingResult enterWaiting(EnterWaitingCommand command){
 
-        waitingRepository.findWaitingByRestaurantId(command.restaurantId())
-                .stream()
-                .filter(w -> w.getUserId().equals(command.userId()))
-                .findAny()
-                .ifPresent(w ->{throw new WaitingException(WaitingErrorCode.ALREADY_IN); });
+        if (waitingActivationPort.existsUser(command.restaurantId(), command.userId())) {
+            throw new WaitingException(WaitingErrorCode.ALREADY_IN);
+        }
 
         Waiting waiting = Waiting.create(command.userId(), command.restaurantId());
 
@@ -61,6 +59,10 @@ public class WaitingService {
 
         // redis 순번 등록
         waitingActivationPort.add(command.restaurantId(), saved.getToken().value());
+
+        // 이후 중복 등록 시도 시 Redis에서 바로 차단
+        waitingActivationPort.addUser(command.restaurantId(), command.userId());
+
         // redis 순번 조회
         Long position = waitingActivationPort.getPosition(
                 command.restaurantId(), waiting.getToken().value()
@@ -99,6 +101,8 @@ public class WaitingService {
         waitingRepository.save(waiting);
         waitingRepository.softDelete(waitingId, deletedBy);
         waitingActivationPort.remove(waiting.getRestaurantId(), waiting.getToken().value());
+        // 취소 후 재등록 가능하도록 플래그 제거
+        waitingActivationPort.removeUser(waiting.getRestaurantId(), waiting.getUserId());
     }
 
     // ACTIVE 상태인지 검증 - 예약 서비스가 예약 전 호출
@@ -168,7 +172,10 @@ public class WaitingService {
 
                 // 2. DB ACTIVE 전환
                 waiting.activate();
+
                 waitingRepository.save(waiting);
+                // ACTIVE 전환 후 예약 완료 시 재등록 가능하도록 플래그 제거
+                waitingActivationPort.removeUser(restaurantId, waiting.getUserId());
 
                 // 3. 동일한 Outbox 인스턴스 PROCESSED 로 update
                 outbox.markProcessed(LocalDateTime.now());
@@ -194,8 +201,16 @@ public class WaitingService {
         expired.forEach(waiting -> {
             waiting.expire();
             waitingRepository.save(waiting);
-            waitingActivationPort.remove(waiting.getRestaurantId(), waiting.getToken().value());
+            waitingActivationPort.remove(
+                    waiting.getRestaurantId(),
+                    waiting.getToken().value());
+            waitingActivationPort.removeUser(
+                    waiting.getRestaurantId(),
+                    waiting.getUserId()
+            );
         });
+
+
     }
 
     public void retryPendingOutbox(){

--- a/src/main/java/com/michelet/waiting/application/service/WaitingService.java
+++ b/src/main/java/com/michelet/waiting/application/service/WaitingService.java
@@ -46,31 +46,36 @@ public class WaitingService {
             UUID.fromString("00000000-0000-0000-0000-000000000001");
 
     // 대기 등록
-    public WaitingResult enterWaiting(EnterWaitingCommand command){
+    public WaitingResult enterWaiting(EnterWaitingCommand command) {
 
-        if (waitingActivationPort.existsUser(command.restaurantId(), command.userId())) {
+        // Redis SETNX로 원자적 중복 체크 + 플래그 저장
+        // false 반환 시 이미 대기 중인 유저
+        if (!waitingActivationPort.tryAddUser(command.restaurantId(), command.userId())) {
             throw new WaitingException(WaitingErrorCode.ALREADY_IN);
         }
 
-        Waiting waiting = Waiting.create(command.userId(), command.restaurantId());
+        try {
+            Waiting waiting = Waiting.create(command.userId(), command.restaurantId());
 
-        // DB 저장
-        Waiting saved = waitingRepository.save(waiting);
+            // DB 저장
+            Waiting saved = waitingRepository.save(waiting);
 
-        // redis 순번 등록
-        waitingActivationPort.add(command.restaurantId(), saved.getToken().value());
+            // Redis 순번 등록
+            waitingActivationPort.add(command.restaurantId(), saved.getToken().value());
 
-        // 이후 중복 등록 시도 시 Redis에서 바로 차단
-        waitingActivationPort.addUser(command.restaurantId(), command.userId());
+            // Redis 순번 조회
+            Long position = waitingActivationPort.getPosition(
+                    command.restaurantId(), waiting.getToken().value()
+            );
 
-        // redis 순번 조회
-        Long position = waitingActivationPort.getPosition(
-                command.restaurantId(), waiting.getToken().value()
-        );
+            return WaitingResult.of(saved, position);
 
-
-        return WaitingResult.of(saved, position);
-
+        } catch (Exception e) {
+            // DB 저장 실패 시 Redis 유저 플래그 제거
+            // 재등록 가능하도록
+            waitingActivationPort.removeUser(command.restaurantId(), command.userId());
+            throw e;
+        }
     }
 
     // 상태 조회

--- a/src/main/java/com/michelet/waiting/application/service/WaitingService.java
+++ b/src/main/java/com/michelet/waiting/application/service/WaitingService.java
@@ -147,6 +147,9 @@ public class WaitingService {
         List<ScoredToken> scoredTokens = waitingActivationPort.popNextTokensWithScore(restaurantId,batchSize);
 
         for(ScoredToken scoredToken : scoredTokens){
+
+            boolean activeSaved = false;
+
             try{
                 Optional<Waiting> waitingOpt = waitingRepository.findByToken(scoredToken.token());
                 if (waitingOpt.isEmpty()) {
@@ -172,8 +175,10 @@ public class WaitingService {
 
                 // 2. DB ACTIVE 전환
                 waiting.activate();
-
                 waitingRepository.save(waiting);
+
+                activeSaved = true;
+
                 // ACTIVE 전환 후 예약 완료 시 재등록 가능하도록 플래그 제거
                 waitingActivationPort.removeUser(restaurantId, waiting.getUserId());
 
@@ -182,11 +187,13 @@ public class WaitingService {
                 waitingOutboxRepository.update(outbox);
             }catch (Exception e){
                 // 4. DB 저장 실패 시 원래 score로 Redis 복구
-                waitingActivationPort.addWithScore(
-                        restaurantId,
-                        scoredToken.token(),
-                        scoredToken.score()
-                );
+                if (!activeSaved) {
+                    waitingActivationPort.addWithScore(
+                            restaurantId,
+                            scoredToken.token(),
+                            scoredToken.score()
+                    );
+                }
 
                 log.warn("[스케줄러] ACTIVE 전환 실패 Redis 복구 - token : {}",
                         scoredToken.token(),e);

--- a/src/main/java/com/michelet/waiting/domain/repository/WaitingRepository.java
+++ b/src/main/java/com/michelet/waiting/domain/repository/WaitingRepository.java
@@ -1,7 +1,6 @@
 package com.michelet.waiting.domain.repository;
 
 import com.michelet.waiting.domain.entity.Waiting;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +12,6 @@ public interface WaitingRepository {
     Optional<Waiting> findByToken(String token);
     Optional<Waiting> findById(UUID id);
     Optional<Waiting> findByAccessToken(String accessToken);
-    List<Waiting> findWaitingByRestaurantId(UUID restaurantId);
     List<Waiting> findExpiredActives(LocalDateTime expiredBefore);
     List<UUID> findDistinctRestaurantIdsWithWaiting();
     void softDelete(UUID waitingId, UUID deletedBy);

--- a/src/main/java/com/michelet/waiting/infrastructure/persistence/jpa/WaitingRepositoryImpl.java
+++ b/src/main/java/com/michelet/waiting/infrastructure/persistence/jpa/WaitingRepositoryImpl.java
@@ -1,16 +1,14 @@
 package com.michelet.waiting.infrastructure.persistence.jpa;
 
 import com.michelet.waiting.domain.entity.Waiting;
-import com.michelet.waiting.domain.enums.WaitingStatus;
 import com.michelet.waiting.domain.repository.WaitingRepository;
 import com.michelet.waiting.infrastructure.persistence.querydsl.WaitingQueryRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -40,14 +38,6 @@ public class WaitingRepositoryImpl implements WaitingRepository {
     public Optional<Waiting> findByAccessToken(String accessToken) {
         return jpa.findByAccessTokenAndDeletedAtIsNull(accessToken)
                 .map(WaitingJpaEntity::toDomain);
-    }
-
-    @Override
-    public List<Waiting> findWaitingByRestaurantId(UUID restaurantId) {
-        return jpa.findByRestaurantIdAndStatusAndDeletedAtIsNull(restaurantId, WaitingStatus.WAITING)
-                .stream()
-                .map(WaitingJpaEntity::toDomain)
-                .toList();
     }
 
     @Override

--- a/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
+++ b/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
@@ -119,22 +119,15 @@ public class RedisWaitingActivationAdapter implements WaitingActivationPort {
         redisTemplate.opsForZSet().remove(buildKey(restaurantId), token);
     }
 
-    // 유저 중복 등록 여부 확인
-    // Redis key 존재 여부로 O(1) 체크
     @Override
-    public boolean existsUser(UUID restaurantId, UUID userId) {
-        return redisTemplate.hasKey(buildUserKey(restaurantId, userId));
+    public boolean tryAddUser(UUID restaurantId, UUID userId) {
+        Objects.requireNonNull(restaurantId, "restaurantId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
+        String key = buildUserKey(restaurantId, userId);
+        // SETNX — 키가 없을 때만 저장, 있으면 false 반환
+        Boolean result = redisTemplate.opsForValue().setIfAbsent(key, "1");
+        return Boolean.TRUE.equals(result);
     }
-
-    // 유저 플래그 저장
-    // 대기 등록 성공 시 호출
-    @Override
-    public void addUser(UUID restaurantId, UUID userId) {
-        redisTemplate.opsForValue().set(
-                buildUserKey(restaurantId, userId), "1"
-        );
-    }
-
 
     // 유저 플래그 제거
     // 취소/완료/만료/ACTIVE 전환 시 호출

--- a/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
+++ b/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class RedisWaitingActivationAdapter implements WaitingActivationPort {
 
     private final RedisTemplate<String,String> redisTemplate;
+    private static final String USER_PREFIX = "waiting:user:";
     private static final String PREFIX = "waiting:queue:";
     private static final String SEQ_PREFIX = "waiting:seq:";
 
@@ -34,6 +35,13 @@ public class RedisWaitingActivationAdapter implements WaitingActivationPort {
         Objects.requireNonNull(restaurantId, "restaurantId must not be null");
         return SEQ_PREFIX + restaurantId;
     }
+
+    // userKey create - "waiting:user:{restaurantId}:{userId}"
+    // 유저별 식당 대기 등록 여부 관리
+    private String buildUserKey(UUID restaurantId, UUID userId) {
+        return USER_PREFIX + restaurantId + ":" + userId;
+    }
+
 
     private void validateToken(String token){
         if(token == null || token.isBlank())
@@ -107,5 +115,29 @@ public class RedisWaitingActivationAdapter implements WaitingActivationPort {
     public void remove(UUID restaurantId, String token) {
         validateToken(token);
         redisTemplate.opsForZSet().remove(buildKey(restaurantId), token);
+    }
+
+    // 유저 중복 등록 여부 확인
+    // Redis key 존재 여부로 O(1) 체크
+    @Override
+    public boolean existsUser(UUID restaurantId, UUID userId) {
+        return redisTemplate.hasKey(buildUserKey(restaurantId, userId));
+    }
+
+    // 유저 플래그 저장
+    // 대기 등록 성공 시 호출
+    @Override
+    public void addUser(UUID restaurantId, UUID userId) {
+        redisTemplate.opsForValue().set(
+                buildUserKey(restaurantId, userId), "1"
+        );
+    }
+
+
+    // 유저 플래그 제거
+    // 취소/완료/만료/ACTIVE 전환 시 호출
+    @Override
+    public void removeUser(UUID restaurantId, UUID userId) {
+        redisTemplate.delete(buildUserKey(restaurantId, userId));
     }
 }

--- a/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
+++ b/src/main/java/com/michelet/waiting/infrastructure/redis/RedisWaitingActivationAdapter.java
@@ -39,6 +39,8 @@ public class RedisWaitingActivationAdapter implements WaitingActivationPort {
     // userKey create - "waiting:user:{restaurantId}:{userId}"
     // 유저별 식당 대기 등록 여부 관리
     private String buildUserKey(UUID restaurantId, UUID userId) {
+        Objects.requireNonNull(restaurantId, "restaurantId must not be null");
+        Objects.requireNonNull(userId, "userId must not be null");
         return USER_PREFIX + restaurantId + ":" + userId;
     }
 


### PR DESCRIPTION
## 📝 작업 내용
대기 등록 시 DB 조회가 병목현상이 일어나서 동시 80명 한계 발생,
대기열 서비스의 본연의 역할 ( 트래픽 폭발 시 예약 서비스 보호 )을 위해
중복 체크를 Redis로 전환하여 성능 개선 예상

## 🚀 주요 변경 사항
> 완료한 이슈 번호 #41 
> Close #41


## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
<img width="1065" height="229" alt="image" src="https://github.com/user-attachments/assets/4bea026b-4353-4d85-80d9-1fd413403cef" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 중복 대기 등록 차단 로직을 최적화하여 더욱 빠르고 안정적인 응답 제공
  * 대기열 라이프사이클 전반에서 사용자 상태 관리 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/waiting-service/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->