### PR TITLE
[FIX]  ACTIVE 전환 시 Redis 유저 플래그 제거 시점 수정

### DIFF
--- a/src/main/java/com/michelet/waiting/application/service/WaitingService.java
+++ b/src/main/java/com/michelet/waiting/application/service/WaitingService.java
@@ -68,6 +68,12 @@ public class WaitingService {
                     command.restaurantId(), waiting.getToken().value()
             );
 
+            if (position == null) {
+                Waiting updated = waitingRepository.findById(saved.getId())
+                        .orElseThrow(() -> new WaitingException(WaitingErrorCode.NOT_FOUND));
+                return WaitingResult.of(updated);
+            }
+
             return WaitingResult.of(saved, position);
 
         } catch (Exception e) {

--- a/src/main/java/com/michelet/waiting/application/service/WaitingService.java
+++ b/src/main/java/com/michelet/waiting/application/service/WaitingService.java
@@ -144,6 +144,9 @@ public class WaitingService {
         waitingRepository.softDelete(waitingId, SYSTEM_UUID);
 
         waitingActivationPort.remove(waiting.getRestaurantId(), waiting.getToken().value());
+
+        // 예약 완료 후 재등록 가능하도록 유저 플래그 제거
+        waitingActivationPort.removeUser(waiting.getRestaurantId(), waiting.getUserId());
     }
 
     // 스케줄러 - N명씩 입장 허용
@@ -189,9 +192,6 @@ public class WaitingService {
                 waitingRepository.save(waiting);
 
                 activeSaved = true;
-
-                // ACTIVE 전환 후 예약 완료 시 재등록 가능하도록 플래그 제거
-                waitingActivationPort.removeUser(restaurantId, waiting.getUserId());
 
                 // 3. 동일한 Outbox 인스턴스 PROCESSED 로 update
                 outbox.markProcessed(LocalDateTime.now());


### PR DESCRIPTION
## 📝 작업 내용
> DB 유니크 제약 위반 발생하는 버그 수정

## 🚀 주요 변경 사항
> 완료한 이슈 번호 #45 
> Close #45 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
><img width="1019" height="282" alt="image" src="https://github.com/user-attachments/assets/a9bd3ebc-609f-425c-b56c-8975eba7a9e2" />
## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 대기열 순번 조회 실패 시 안정적인 정보 조회 로직 개선
  * 예약 완료 후 사용자가 대기열에 재등록 가능하도록 처리 개선

* **성능 개선**
  * 대기열 활성화 프로세스의 사용자 플래그 제거 타이밍 최적화로 시스템 안정성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/waiting-service/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->